### PR TITLE
chore: modify config for expo publish

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,8 @@
 {
   "expo": {
-    "name": "solemates-frontend",
-    "slug": "solemates-frontend",
+    "name": "SoleMates",
+    "slug": "solemates",
+    "description": "Find running buddies in Tokyo",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -14,9 +15,7 @@
     "updates": {
       "fallbackToCacheTimeout": 0
     },
-    "assetBundlePatterns": [
-      "**/*"
-    ],
+    "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true
     },
@@ -28,6 +27,7 @@
     },
     "web": {
       "favicon": "./assets/favicon.png"
-    }
+    },
+    "owner": "ccp4"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "expo": "~45.0.0",
         "expo-cli": "^5.4.9",
         "expo-status-bar": "~1.3.0",
+        "expo-updates": "~0.13.2",
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-native": "0.68.2",
@@ -9167,6 +9168,11 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-eas-client": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-0.2.1.tgz",
+      "integrity": "sha512-XlZr57iHxqo3+AT2TtcRipMuQEyXnTUAv7H5+KVvj6EEJEAHmwc9wZZdKzqf0MbVRUTOawZsl/b2iYanf+kQsQ=="
+    },
     "node_modules/expo-error-recovery": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/expo-error-recovery/-/expo-error-recovery-3.1.0.tgz",
@@ -9199,12 +9205,25 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.3.0.tgz",
+      "integrity": "sha512-ceo0pWFJqRAsNjZWX3rVDhy+NDzmrBNFOdvW+HE4EHqlt+OEUu9INIYKO8fU+g3ifI0VcKqHfvvj5wKsSpvPBw=="
+    },
     "node_modules/expo-keep-awake": {
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-10.1.1.tgz",
       "integrity": "sha512-9zC0sdhQljUeMr2yQ7o4kzEZXVAy82fFOAZE1+TwPL7qR0b0sphe7OJ5T1GX1qLcwuVaJ8YewaPoLSHRk79+Rg==",
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-0.3.0.tgz",
+      "integrity": "sha512-HegANp+KpZlMX0T2Zb8X7mAVkCThFDq1wjLIjkrSLHhKLczYI2xa/Z5Nk0Tm7qPdGT8NTInCDoOL/nUMtKdNyQ==",
+      "dependencies": {
+        "expo-json-utils": "~0.3.0"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -9416,6 +9435,53 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-1.3.0.tgz",
       "integrity": "sha512-UszYUsT8A8jSUebrXht095Iwv5VIdg61LPuyNNoC5gFP0E9G+8LgX68deqR4zhJOlbsgSH2cixxKhrGW+1HPZg=="
+    },
+    "node_modules/expo-structured-headers": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-2.2.1.tgz",
+      "integrity": "sha512-nY6GuvoS/U5XdhfBNmvXGRoGzIXywXpSZs2wdiP+FbS79P9UWyEqzgARrBTF+6pQxUVMs6/vdffxRpwhjwYPug=="
+    },
+    "node_modules/expo-updates": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-0.13.2.tgz",
+      "integrity": "sha512-2ZthmyxYuN/c71y2oLNz9fdVXLf7ggxAw3Tfy+kwtGOTKNyOf/YoG+SwX7a0v+jZTJnuorEj5FuNf3wrniQ7+w==",
+      "dependencies": {
+        "@expo/code-signing-certificates": "0.0.1",
+        "@expo/config": "^6.0.14",
+        "@expo/config-plugins": "^4.0.14",
+        "@expo/metro-config": "~0.3.7",
+        "arg": "4.1.0",
+        "expo-eas-client": "~0.2.0",
+        "expo-manifests": "~0.3.0",
+        "expo-structured-headers": "~2.2.0",
+        "expo-updates-interface": "~0.6.0",
+        "fbemitter": "^3.0.0",
+        "resolve-from": "^5.0.0",
+        "uuid": "^3.4.0"
+      },
+      "bin": {
+        "expo-updates": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-0.6.0.tgz",
+      "integrity": "sha512-oQcGTsE8mSkSxENPlWjZPGoJpt3RFDNPuO5d8shBDxBb4ZNH/W2ojavSFQMaLbNMoS0bYQQhzbRNEIBd306QMg==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-updates/node_modules/@expo/code-signing-certificates": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@expo/code-signing-certificates/-/code-signing-certificates-0.0.1.tgz",
+      "integrity": "sha512-m1AVZGsMgpXRLULQ331AZdxh1D64Qbcb6z7A19JmXUrCQu3591zPn1wjR6J63/Dzi00m5TR5w+9GvqnFY5X//Q==",
+      "dependencies": {
+        "node-forge": "^1.2.1",
+        "nullthrows": "^1.1.1"
+      }
     },
     "node_modules/express": {
       "version": "4.16.4",
@@ -29180,6 +29246,11 @@
         "uuid": "^3.3.2"
       }
     },
+    "expo-eas-client": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-0.2.1.tgz",
+      "integrity": "sha512-XlZr57iHxqo3+AT2TtcRipMuQEyXnTUAv7H5+KVvj6EEJEAHmwc9wZZdKzqf0MbVRUTOawZsl/b2iYanf+kQsQ=="
+    },
     "expo-error-recovery": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/expo-error-recovery/-/expo-error-recovery-3.1.0.tgz",
@@ -29204,11 +29275,24 @@
         "fontfaceobserver": "^2.1.0"
       }
     },
+    "expo-json-utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.3.0.tgz",
+      "integrity": "sha512-ceo0pWFJqRAsNjZWX3rVDhy+NDzmrBNFOdvW+HE4EHqlt+OEUu9INIYKO8fU+g3ifI0VcKqHfvvj5wKsSpvPBw=="
+    },
     "expo-keep-awake": {
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-10.1.1.tgz",
       "integrity": "sha512-9zC0sdhQljUeMr2yQ7o4kzEZXVAy82fFOAZE1+TwPL7qR0b0sphe7OJ5T1GX1qLcwuVaJ8YewaPoLSHRk79+Rg==",
       "requires": {}
+    },
+    "expo-manifests": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-0.3.0.tgz",
+      "integrity": "sha512-HegANp+KpZlMX0T2Zb8X7mAVkCThFDq1wjLIjkrSLHhKLczYI2xa/Z5Nk0Tm7qPdGT8NTInCDoOL/nUMtKdNyQ==",
+      "requires": {
+        "expo-json-utils": "~0.3.0"
+      }
     },
     "expo-modules-autolinking": {
       "version": "0.8.1",
@@ -29367,6 +29451,47 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-1.3.0.tgz",
       "integrity": "sha512-UszYUsT8A8jSUebrXht095Iwv5VIdg61LPuyNNoC5gFP0E9G+8LgX68deqR4zhJOlbsgSH2cixxKhrGW+1HPZg=="
+    },
+    "expo-structured-headers": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-2.2.1.tgz",
+      "integrity": "sha512-nY6GuvoS/U5XdhfBNmvXGRoGzIXywXpSZs2wdiP+FbS79P9UWyEqzgARrBTF+6pQxUVMs6/vdffxRpwhjwYPug=="
+    },
+    "expo-updates": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-0.13.2.tgz",
+      "integrity": "sha512-2ZthmyxYuN/c71y2oLNz9fdVXLf7ggxAw3Tfy+kwtGOTKNyOf/YoG+SwX7a0v+jZTJnuorEj5FuNf3wrniQ7+w==",
+      "requires": {
+        "@expo/code-signing-certificates": "0.0.1",
+        "@expo/config": "^6.0.14",
+        "@expo/config-plugins": "^4.0.14",
+        "@expo/metro-config": "~0.3.7",
+        "arg": "4.1.0",
+        "expo-eas-client": "~0.2.0",
+        "expo-manifests": "~0.3.0",
+        "expo-structured-headers": "~2.2.0",
+        "expo-updates-interface": "~0.6.0",
+        "fbemitter": "^3.0.0",
+        "resolve-from": "^5.0.0",
+        "uuid": "^3.4.0"
+      },
+      "dependencies": {
+        "@expo/code-signing-certificates": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/@expo/code-signing-certificates/-/code-signing-certificates-0.0.1.tgz",
+          "integrity": "sha512-m1AVZGsMgpXRLULQ331AZdxh1D64Qbcb6z7A19JmXUrCQu3591zPn1wjR6J63/Dzi00m5TR5w+9GvqnFY5X//Q==",
+          "requires": {
+            "node-forge": "^1.2.1",
+            "nullthrows": "^1.1.1"
+          }
+        }
+      }
+    },
+    "expo-updates-interface": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-0.6.0.tgz",
+      "integrity": "sha512-oQcGTsE8mSkSxENPlWjZPGoJpt3RFDNPuO5d8shBDxBb4ZNH/W2ojavSFQMaLbNMoS0bYQQhzbRNEIBd306QMg==",
+      "requires": {}
     },
     "express": {
       "version": "4.16.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-native-paper": "^4.12.1",
     "react-native-safe-area-context": "4.2.4",
     "react-native-screens": "~3.11.1",
-    "react-native-web": "0.17.7"
+    "react-native-web": "0.17.7",
+    "expo-updates": "~0.13.2"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"


### PR DESCRIPTION
## Issue
Closes CCP4-senior/senior-project#18

## Feature
- App published to expo (https://expo.dev/@ccp4/solemates?serviceType=classic&distribution=expo-go)
- Now it's accessible by all android user who knows the QR code and all ios user who is added to the team account
