### PR TITLE
127 display map marker for participants only

### DIFF
--- a/screens/event-details/EventDetailsScreen.js
+++ b/screens/event-details/EventDetailsScreen.js
@@ -320,7 +320,7 @@ const EventDetailsScreen = ({ navigation }) => {
                           latitude: region.latitude,
                           longitude: region.longitude,
                           latitudeDelta: 0.002,
-                          longitudeDelta: 0.0121,
+                          longitudeDelta: 0.002,
                         }}
                         provider={PROVIDER_DEFAULT}
                       >
@@ -339,7 +339,7 @@ const EventDetailsScreen = ({ navigation }) => {
                             latitude: region.latitude,
                             longitude: region.longitude,
                           }}
-                          radius={200}
+                          radius={50}
                           strokeWidth={2}
                         ></Circle>
                       </MapView>


### PR DESCRIPTION
### Issue
Closes CCP4-senior/senior-project#127

### Features
- only event participants or event owners can see iOS map
- updated zoom level and marker radius for map display

<img src="https://user-images.githubusercontent.com/30029618/177814813-04c9afcb-d974-49bb-a42a-a22d3535a631.png" width="200">


<img src="https://user-images.githubusercontent.com/30029618/177814871-9ca27f73-037b-479c-8b1f-5e84332b7250.png" width="200">
