### PR TITLE
fix: make light mode permanent

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "automatic",
+    "userInterfaceStyle": "light",
     "splash": {
       "image": "./assets/images/splashScreen2.png",
       "resizeMode": "cover",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "expo-secure-store": "~11.2.0",
         "expo-splash-screen": "~0.15.1",
         "expo-status-bar": "~1.3.0",
+        "expo-system-ui": "~1.2.0",
         "expo-updates": "~0.13.2",
         "firebase": "^9.8.3",
         "jwt-decode": "^3.1.2",
@@ -10426,6 +10427,19 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-2.2.1.tgz",
       "integrity": "sha512-nY6GuvoS/U5XdhfBNmvXGRoGzIXywXpSZs2wdiP+FbS79P9UWyEqzgARrBTF+6pQxUVMs6/vdffxRpwhjwYPug=="
+    },
+    "node_modules/expo-system-ui": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/expo-system-ui/-/expo-system-ui-1.2.0.tgz",
+      "integrity": "sha512-jynjFNz38FeY/2u4EKvLJdIk0hZAhicd9lbjSRJUDTjhGhQmYDsCQ32NKp/X3DwBkugAP5nwDwa5S3eGk5i80Q==",
+      "dependencies": {
+        "@expo/config-plugins": "^4.0.14",
+        "@react-native/normalize-color": "^2.0.0",
+        "debug": "^4.3.2"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
     },
     "node_modules/expo-updates": {
       "version": "0.13.2",
@@ -31588,6 +31602,16 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-2.2.1.tgz",
       "integrity": "sha512-nY6GuvoS/U5XdhfBNmvXGRoGzIXywXpSZs2wdiP+FbS79P9UWyEqzgARrBTF+6pQxUVMs6/vdffxRpwhjwYPug=="
+    },
+    "expo-system-ui": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/expo-system-ui/-/expo-system-ui-1.2.0.tgz",
+      "integrity": "sha512-jynjFNz38FeY/2u4EKvLJdIk0hZAhicd9lbjSRJUDTjhGhQmYDsCQ32NKp/X3DwBkugAP5nwDwa5S3eGk5i80Q==",
+      "requires": {
+        "@expo/config-plugins": "^4.0.14",
+        "@react-native/normalize-color": "^2.0.0",
+        "debug": "^4.3.2"
+      }
     },
     "expo-updates": {
       "version": "0.13.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "react-native-screens": "~3.11.1",
     "react-native-uuid": "^2.0.1",
     "react-native-web": "0.17.7",
-    "expo-splash-screen": "~0.15.1"
+    "expo-splash-screen": "~0.15.1",
+    "expo-system-ui": "~1.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"


### PR DESCRIPTION
Closes CCP4-senior/senior-project#142.

## Features
- Fixes the terrible dark mode UI!
- Dark mode does NOT appear in the simulator. I noticed it only on my real iPhone 12.
- only a single line of code in app.json was changed



## How to test

1. Do `npm install` (the new package is called `expo-system-ui`)

2. Turn on Dark Mode on your phone

![setting](https://user-images.githubusercontent.com/83651965/178223955-ab6640f8-1c27-4850-8939-0bbf451f34d5.jpeg)


4. Go to an Event, make sure there is not Dark Mode UI.

## Before

![IMG_2393 2 Large](https://user-images.githubusercontent.com/83651965/178223975-601255e8-d03d-4cfa-a4c2-7f539079ec1d.jpeg)


## After 

![IMG_2394 Large](https://user-images.githubusercontent.com/83651965/178223996-bd9cd218-3946-4237-9a1c-dadfd53d29fc.jpeg)
